### PR TITLE
typo

### DIFF
--- a/bin/hacks/bypass.json
+++ b/bin/hacks/bypass.json
@@ -101,8 +101,8 @@
 	},
 	
 	{
-	  "name": "Potbar Shop",
-	  "desc": "Unlocks Potbar's shop in the treasure room.",
+	  "name": "Potbor Shop",
+	  "desc": "Unlocks Potbor's shop in the treasure room.",
 	  "opcodes": [
 	    {"addr": "0x15706B", "on": "90 90 90 90 90 90", "off": "0F 8C B4 01 00 00 00"}
 	  ]


### PR DESCRIPTION
"potbar" to "potbor"